### PR TITLE
Fix/ios handle nfc popup

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -53,7 +53,7 @@ export const runAuthCmd = (
     command: {
       cmd: "RUN_AUTH",
       tcTokenURL,
-      handleInterrupt: false,
+      handleInterrupt: true,
       messages: {
         sessionStarted:
           "Please place your ID card on the top of the device's back side.",


### PR DESCRIPTION
Falling back to AA2 handling NFC interrupt, otherwise, it is hanged in an unpredictable state: progress in always 0%, and it keeps showing up after a successful card read