### PR TITLE
feat(auth-msg): adding handler for the auth msg for accept cmd

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -274,6 +274,7 @@ export const acceptAuthReqCmd = (): AcceptCommand<
             return resolve(message)
           case Messages.auth:
             handleAuthResult && handleAuthResult(message.url)
+            return resolve(message)
           default:
             return reject(new Error('Unknown message type'))
         }


### PR DESCRIPTION
### Description
AUTH msg can come in within ACCEPT cmd when user presses CANCEL on NFC popup - iOS